### PR TITLE
add exportLHSCheckAccess.js to do provider checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Local
+accounts.csv
+config.js

--- a/exportLHSCheckAccess.js
+++ b/exportLHSCheckAccess.js
@@ -1,0 +1,158 @@
+var axios = require('axios');
+const fastcsv = require('fast-csv');
+const fs = require('fs');
+var parse = require('csv-parse');
+const { exit } = require('process');
+const config = require('./config');
+const args = require('yargs').argv;
+
+const cliProgress = require('cli-progress');
+const bar1 = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
+
+process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
+
+async function getProviderLines(stationNo, duz) {
+  try {
+    // First request to get the token
+    const tokenResponse = await axios.post(
+      config.VistaApiX.tokenUrl,
+      {
+        "key": config.KeyX
+      }
+    );
+
+    // Extract the token from the response
+    const token = tokenResponse.data.data.token;
+
+    // Second request using the token
+    const invokeResponse = await axios.post(
+      config.VistaApiX.url + '/vista-sites/' + stationNo + '/users/' + duz + '/rpc/invoke',
+      {
+        "context": "OR CPRS GUI CHART",
+        "rpc": "ORWU NEWPERS",
+        "jsonResult": false,
+        "parameters": [
+          { "string": "" },
+          { "string": "-1" },
+          { "string": "PROVIDER" },
+        ]
+      },
+      {
+        headers: {
+          'authorization': 'Bearer ' + token
+        }
+      });
+
+    // Extract and return the payload from the response
+    return invokeResponse.data.payload.split('\n');
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
+async function getCheckAccessLine(stationNo, duz, providerDuz, option) {
+  try {
+    // First request to get the token
+    const tokenResponse = await axios.post(
+      config.VistaApiX.tokenUrl,
+      {
+        "key": config.KeyX
+      }
+    );
+
+    // Extract the token from the response
+    const token = tokenResponse.data.data.token;
+
+    // Second request using the token
+    const toolMenuResponse = await axios.post(
+      config.VistaApiX.url + '/vista-sites/' + stationNo + '/users/' + duz + '/rpc/invoke',
+      {
+        "context": "LHS RPC CONTEXT",
+        "rpc": "LHS CHECK OPTION ACCESS",
+        "jsonResult": false,
+        "parameters": [
+          { "string": providerDuz },
+          { "string": option },
+        ]
+      },
+      {
+        headers: {
+          'authorization': 'Bearer ' + token
+        }
+      });
+
+    // Extract and return the payload from the response
+    return toolMenuResponse.data.payload;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+}
+
+function getStations() {
+  return new Promise(function (resolve, reject) {
+    var stations = []
+    fs.createReadStream("accounts.csv")
+      .pipe(parse.parse({ delimiter: ',' }))
+      .on('data', function (csvrow) {
+        var row = {
+          "stationNo": csvrow[0],
+          "accountDuz": csvrow[1],
+        }
+        stations.push(row)
+      })
+      .on('end', () => resolve(stations));
+  })
+}
+
+const entryPoint = async () => {
+
+  const ws = fs.createWriteStream("results.csv");
+
+  const csvStream = fastcsv.format({ headers: true, includeEndRowDelimiter: true });
+  csvStream.pipe(ws);
+
+  try {
+    var stations = await getStations()
+  }
+  catch (error) {
+    console.error(error);
+    throw error;
+  };
+
+  bar1.start(stations.length, 0);
+
+  try {
+    for (const station of stations) {
+
+      var providerLines = await getProviderLines(station.stationNo, station.accountDuz);
+
+      for (const providerLine of providerLines) {
+        var [providerDuz, providerName] = providerLine.split("^");
+        var checkAccessLine = await getCheckAccessLine(station.stationNo, station.accountDuz, providerDuz, args.option)
+        csvStream.write({ stationNo: station.stationNo, option: args.option, checkAccessLine, providerDuz, providerName })
+      }
+
+      bar1.increment();
+
+    }
+  }
+  catch (error) {
+    console.error(error)
+  }
+
+  bar1.stop();
+
+  csvStream.end();
+  ws.close();
+
+}
+
+entryPoint()
+
+
+
+
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "cli-progress": "^3.12.0",
         "csv-parse": "^5.5.2",
         "fast-csv": "^4.3.6",
-        "fs": "^0.0.1-security"
+        "fs": "^0.0.1-security",
+        "yargs": "^17.7.2"
       }
     },
     "node_modules/@fast-csv/format": {
@@ -56,6 +57,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -81,6 +96,35 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -110,6 +154,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-csv": {
       "version": "4.3.6",
@@ -159,6 +211,14 @@
       "version": "0.0.1-security",
       "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
       "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -232,6 +292,14 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -254,6 +322,55 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cli-progress": "^3.12.0",
     "csv-parse": "^5.5.2",
     "fast-csv": "^4.3.6",
-    "fs": "^0.0.1-security"
+    "fs": "^0.0.1-security",
+    "yargs": "^17.7.2"
   }
 }


### PR DESCRIPTION
This is meant to support some ongoing debugging and prep work on two fronts: checking for bugs in access checks and ensuring access has propagated properly.

This requires a specific argument on the command line:

`node ./exportLHSCheckAccess.js --option="SDECRPC"`